### PR TITLE
Fix port order, visible in the effect of `any`

### DIFF
--- a/T21.cpp
+++ b/T21.cpp
@@ -112,7 +112,7 @@ bool T21::step() {
 	    [&](kblib::constant<std::size_t, instr::hcf>, seq_instr) {
 		    log << "hcf";
 		    log_debug(std::move(log).str());
-		    log_debug("\ts = ", kblib::etoi(s));
+		    log_debug("\ts = ", state_name(s));
 		    throw std::runtime_error{"HCF"};
 		    return true;
 	    },
@@ -254,7 +254,7 @@ bool T21::step() {
 		    }
 	    });
 	log_debug(std::move(log).str());
-	log_debug("\ts = ", kblib::etoi(s));
+	log_debug("\ts = ", state_name(s));
 	return r;
 }
 bool T21::finalize() {

--- a/T21.cpp
+++ b/T21.cpp
@@ -42,10 +42,10 @@ void T21::next() {
 
 std::optional<word_t> T21::read(port p, word_t imm) {
 	switch (p) {
-	case port::up:
 	case port::left:
 	case port::right:
 	case port::down:
+	case port::up:
 	case port::D5:
 	case port::D6:
 		return do_read(neighbors[kblib::to_unsigned(kblib::etoi(p))], invert(p));
@@ -54,7 +54,7 @@ std::optional<word_t> T21::read(port p, word_t imm) {
 	case port::acc:
 		return acc;
 	case port::any:
-		for (auto p_ : {port::up, port::left, port::right, port::down, port::D5,
+		for (auto p_ : {port::left, port::right, port::up, port::down, port::D5,
 		                port::D6}) {
 			if (auto r = read(p_)) {
 				last = p_;
@@ -66,6 +66,8 @@ std::optional<word_t> T21::read(port p, word_t imm) {
 		return read(last);
 	case port::immediate:
 		return imm;
+	default:
+		throw std::invalid_argument{""};
 	}
 }
 
@@ -141,9 +143,9 @@ bool T21::step() {
 					    break;
 				    }
 				    [[fallthrough]];
-			    case port::up:
 			    case port::left:
 			    case port::right:
+			    case port::up:
 			    case port::down:
 			    case port::D5:
 			    case port::D6:
@@ -293,7 +295,7 @@ bool T21::finalize() {
 }
 
 std::optional<word_t> T21::read_(port p) {
-	assert(p >= port::up and p <= port::D6);
+	assert(p >= port::left and p <= port::D6);
 	if (write_port == port::any or write_port == p) {
 		auto r = std::exchange(wrt, word_t{});
 		// set write port to flag that the write has completed

--- a/T30.hpp
+++ b/T30.hpp
@@ -32,7 +32,7 @@ struct T30 : node {
 	bool step() override {
 		read = false;
 		if (not wrote and data.size() < max_size) {
-			for (auto p : {port::up, port::left, port::right, port::down, port::D5,
+			for (auto p : {port::left, port::right, port::up, port::down, port::D5,
 			               port::D6}) {
 				if (auto r
 				    = do_read(neighbors[static_cast<std::size_t>(p)], invert(p))) {

--- a/node.hpp
+++ b/node.hpp
@@ -31,6 +31,22 @@ using index_t = std::int16_t;
 constexpr inline int def_T21_size = 15;
 constexpr inline int def_T30_size = 15;
 
+enum class activity { idle, run, read, write };
+
+constexpr static std::string_view state_name(activity s) {
+	switch (s) {
+	case activity::idle:
+		return "IDLE";
+	case activity::run:
+		return "RUN";
+	case activity::read:
+		return "READ";
+	case activity::write:
+		return "WRTE";
+		break;
+	}
+}
+
 enum port : std::int8_t {
 	left,
 	right,
@@ -67,20 +83,7 @@ constexpr port invert(port p) {
 struct node {
  public:
 	enum type_t { T21 = 1, T30, in, out, image, Damaged = -1 };
-	enum class activity { idle, run, read, write };
-	constexpr static std::string_view state_name(activity s) {
-		switch (s) {
-		case activity::idle:
-			return "IDLE";
-		case activity::run:
-			return "RUN";
-		case activity::read:
-			return "READ";
-		case activity::write:
-			return "WRTE";
-			break;
-		}
-	}
+
 	constexpr static std::string_view port_name(port p) {
 		switch (p) {
 		case up:

--- a/node.hpp
+++ b/node.hpp
@@ -32,9 +32,9 @@ constexpr inline int def_T21_size = 15;
 constexpr inline int def_T30_size = 15;
 
 enum port : std::int8_t {
-	up,
 	left,
 	right,
+	up,
 	down,
 	D5, // 3D expansion
 	D6,
@@ -47,23 +47,19 @@ enum port : std::int8_t {
 
 constexpr port invert(port p) {
 	switch (p) {
-	case up:
-		return down;
 	case left:
 		return right;
 	case right:
 		return left;
+	case up:
+		return down;
 	case down:
 		return up;
 	case D5:
 		return D6;
 	case D6:
 		return D5;
-	case nil:
-	case acc:
-	case any:
-	case last:
-	case immediate:
+	default:
 		throw std::invalid_argument{""};
 	}
 }
@@ -144,7 +140,7 @@ struct node {
 
 	friend bool valid(const node* n) { return n and n->type() != node::Damaged; }
 	friend std::optional<word_t> do_read(node* n, port p) {
-		assert(p >= port::up and p <= port::D6);
+		assert(p >= port::left and p <= port::D6);
 		if (not valid(n)) {
 			return std::nullopt;
 		} else {

--- a/parser.cpp
+++ b/parser.cpp
@@ -105,9 +105,9 @@ field parse_layout(std::string_view layout, std::size_t T30_size) {
 		for (const auto x : kblib::range(ret.width)) {
 			if (auto p = ret.node_by_location(x, y); valid(p)) {
 				// safe because node_by_location returns nullptr on OOB
-				p->neighbors[up] = ret.node_by_location(x, y - 1);
 				p->neighbors[left] = ret.node_by_location(x - 1, y);
 				p->neighbors[right] = ret.node_by_location(x + 1, y);
+				p->neighbors[up] = ret.node_by_location(x, y - 1);
 				p->neighbors[down] = ret.node_by_location(x, y + 1);
 			}
 		}
@@ -282,12 +282,12 @@ field parse(std::string_view layout, std::string_view source,
 
 std::string to_string(port p) {
 	switch (p) {
-	case up:
-		return "UP";
 	case left:
 		return "LEFT";
 	case right:
 		return "RIGHT";
+	case up:
+		return "UP";
 	case down:
 		return "DOWN";
 	case D5:
@@ -416,12 +416,12 @@ instr::op parse_op(std::string_view str) {
 }
 
 port parse_port(std::string_view str) {
-	if (str == "UP" or str == "U") {
-		return up;
-	} else if (str == "LEFT" or str == "L") {
+	if (str == "LEFT" or str == "L") {
 		return left;
 	} else if (str == "RIGHT" or str == "R") {
 		return right;
+	} else if (str == "UP" or str == "U") {
+		return up;
 	} else if (str == "DOWN" or str == "D") {
 		return down;
 	} else if (str == "NIL") {

--- a/parser.hpp
+++ b/parser.hpp
@@ -58,8 +58,8 @@ class field {
 			std::string log = kblib::concat("node(", p->x, ',', p->y, ") ");
 			if (type(p.get()) == node::T21) {
 				kblib::append(
-				    log, "s = ", kblib::etoi(static_cast<const T21*>(p.get())->s));
-				if (static_cast<const T21*>(p.get())->s == T21::activity::run) {
+				    log, "s = ", state_name(static_cast<const T21*>(p.get())->s));
+				if (static_cast<const T21*>(p.get())->s == activity::run) {
 					// r = true;
 				}
 			} else if (type(p.get()) == node::in) {


### PR DESCRIPTION
* also fix some warnings about control escaping from switches

Leaderboard stats after the fix:
Matching: 55
Different: 63
Invalid: 106
Crashing: 16
Total: 240