### PR TITLE
Added permissive flag and change line limit counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Other options:
 - `--T21-size N` and `--T30-size M`: override the default size limits on
   instructions in any particular T21 node and values in any particular T30 node
   respectively.
+  - `--permissive`: allow parser extensions (see below).
 - `--cheat-rate C`: change the threshold between /c and /h to any proportion in
   the range 0-1. The default value is .05, or 5%.
 - `-k N`, `--limit-multiplier N`: change the scale factor for dynamic timeouts
@@ -168,10 +169,14 @@ Other options:
 
 Contrary to its documentation, TIS-100 clamps input values in test cases to the
 range [-99, 999]. The simulator allows the full documented range [-999, 999].
+When the `--T21-size` argument is specified, nodes may have more than 15
+instructions. When `--T30-size` is specified, the capacity of T30 (stack memory)
+nodes can be altered.
 
-The parser accepts some things the game does not, namely:
-- When the `--T21-size` argument is specified, nodes may have more than 15
-  instructions.
+When `--permissive` is specified on the command line, the simulator allows
+the following extensions to the assembly language that do not increase the power of
+the language, mostly for convenience when editing files outside of the game.
+- Blank/comment-only lines don't count toward the line count limit.
 - multiple labels on one line (the game allows multiple labels on one
   instruction, but they must have newlines between them).
 - Directional port names (LEFT, RIGHT, UP, DOWN) may be abbreviated to their

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Other options:
 - `--T21-size N` and `--T30-size M`: override the default size limits on
   instructions in any particular T21 node and values in any particular T30 node
   respectively.
-  - `--permissive`: allow parser extensions (see below).
+- `--permissive`: allow parser extensions (see below).
 - `--cheat-rate C`: change the threshold between /c and /h to any proportion in
   the range 0-1. The default value is .05, or 5%.
 - `-k N`, `--limit-multiplier N`: change the scale factor for dynamic timeouts
@@ -179,8 +179,9 @@ the language, mostly for convenience when editing files outside of the game.
 - Blank/comment-only lines don't count toward the line count limit.
 - multiple labels on one line (the game allows multiple labels on one
   instruction, but they must have newlines between them).
-- Directional port names (LEFT, RIGHT, UP, DOWN) may be abbreviated to their
-  first letters.
+- Port names (LEFT, RIGHT, UP, DOWN, ACC, NIL, ANY, LAST) may be abbreviated to
+  prefixes of the full names. Note that "L" is interpreted as "LEFT", not
+  "LAST", and "A" as "ACC", not "ANY".
 - Lines have no length limit.
 
 TIS-100-CXX supports custom levels with any rectangular size, using the new Lua

--- a/field.cpp
+++ b/field.cpp
@@ -384,7 +384,8 @@ static std::string_view pop(std::string_view& str, std::size_t n) {
 	return r;
 }
 
-void field::parse_code(std::string_view source, std::size_t T21_size) {
+void field::parse_code(std::string_view source, std::size_t T21_size,
+                       bool permissive) {
 	source.remove_prefix(std::min(source.find_first_of('@'), source.size()));
 	std::set<int> nodes_seen;
 	while (not source.empty()) {
@@ -407,7 +408,7 @@ void field::parse_code(std::string_view source, std::size_t T21_size) {
 		if (not p) {
 			throw std::invalid_argument{concat("node label ", i, " out of range")};
 		}
-		p->set_code(assemble(section, i, T21_size));
+		p->set_code(assemble(section, i, T21_size, permissive));
 	}
 	finalize_nodes();
 }

--- a/field.hpp
+++ b/field.hpp
@@ -259,7 +259,8 @@ class field {
 
 	/// Read a TIS-100-compatible save file
 	/// @throws std::invalid_argument for any lexing problem
-	void parse_code(std::string_view source, std::size_t T21_size);
+	void parse_code(std::string_view source, std::size_t T21_size,
+	                bool permissive);
 
 	/// returns field with all nodes cloned and resetted
 	field clone() const;

--- a/game.hpp
+++ b/game.hpp
@@ -24,6 +24,7 @@
 constexpr inline uint DIMENSIONS = 2;
 constexpr inline size_t field_width = 4;
 constexpr inline size_t field_height = 3;
+constexpr inline uint max_line_length = 18;
 
 namespace defaults {
 constexpr inline uint T21_size = 15;

--- a/main.cpp
+++ b/main.cpp
@@ -346,6 +346,8 @@ int main(int argc, char** argv) try {
 	    concat("Memory capacity of T30 nodes. (Default ", defaults::T30_size,
 	           ")"),
 	    false, defaults::T30_size, "integer", cmd);
+	TCLAP::SwitchArg permissive("", "permissive", "Enable parser extensions",
+	                            cmd);
 
 	std::vector<std::string> loglevels_allowed{
 	    "none",  "err", "error", "warn", "notice", "info", "trace",
@@ -494,6 +496,7 @@ int main(int argc, char** argv) try {
 		sim.set_T30_size(T30_size.getValue());
 		sim.set_run_fixed(not nofixed.getValue());
 		sim.set_compute_stats(stats.getValue());
+		sim.set_permissive(permissive.getValue());
 	}
 
 	if (dry_run.getValue()) {

--- a/parser.cpp
+++ b/parser.cpp
@@ -180,16 +180,14 @@ std::vector<instr> assemble(std::string_view source, int node,
 		}
 	}
 
-	{
-		// Blank lines and lines consisting only of comments don't count with
-		// --permissive
-		auto effective_lines
-		    = (permissive ? (lines.size() - noncode_lines) : lines.size());
-		if (effective_lines > T21_size) {
-			throw std::invalid_argument{concat("Too many lines of asm for node ",
-			                                   node, "; ", effective_lines,
-			                                   " exceeds limit ", T21_size)};
-		}
+	// Blank lines and lines consisting only of comments don't count with
+	// --permissive
+	if (auto effective_lines
+	    = (permissive ? (lines.size() - noncode_lines) : lines.size());
+	    effective_lines > T21_size) {
+		throw std::invalid_argument{concat("Too many lines of asm for node ",
+		                                   node, "; ", effective_lines,
+		                                   " exceeds limit ", T21_size)};
 	}
 	l = 0;
 	for (const auto& line : lines) {

--- a/parser.cpp
+++ b/parser.cpp
@@ -86,8 +86,9 @@ instr::op parse_op(std::string_view str) {
 	}
 }
 
-// This is a bit more lax than the game, in accepting L, R, U, and D
-// abbreviations
+// permissive=true allows for any prefix of a valid port to be recognized (i.e.
+// L for LEFT, RI for RIGHT, AN for ANY). In case of ambiguity, LEFT and ACC
+// have priority
 port parse_port(std::string_view str, bool permissive) {
 	std::pair<std::string_view, port> ports[]{
 	    {"LEFT", left}, {"RIGHT", right}, {"UP", up},   {"DOWN", down},

--- a/parser.cpp
+++ b/parser.cpp
@@ -88,43 +88,39 @@ instr::op parse_op(std::string_view str) {
 
 // This is a bit more lax than the game, in accepting L, R, U, and D
 // abbreviations
-port parse_port(std::string_view str) {
-	if (str == "LEFT" or str == "L") {
-		return left;
-	} else if (str == "RIGHT" or str == "R") {
-		return right;
-	} else if (str == "UP" or str == "U") {
-		return up;
-	} else if (str == "DOWN" or str == "D") {
-		return down;
-	} else if (str == "NIL") {
-		return nil;
-	} else if (str == "ACC") {
-		return acc;
-	} else if (str == "ANY") {
-		return any;
-	} else if (str == "LAST") {
-		return last;
-	} else {
-		throw std::invalid_argument{kblib::quoted(str)
-		                            + " is not a valid port or register name"};
+port parse_port(std::string_view str, bool permissive) {
+	std::pair<std::string_view, port> ports[]{
+	    {"LEFT", left}, {"RIGHT", right}, {"UP", up},   {"DOWN", down},
+	    {"NIL", nil},   {"ACC", acc},     {"ANY", any}, {"LAST", last},
+	};
+	for (auto [tok, val] : ports) {
+		if (tok.starts_with(str)) {
+			if (not permissive and str != tok) {
+				throw std::invalid_argument{concat(
+				    "Port abbreviation ", kblib::quoted(str), " is not allowed")};
+			}
+			return val;
+		}
 	}
+	throw std::invalid_argument{kblib::quoted(str)
+	                            + " is not a valid port or register name"};
 }
 
 std::vector<instr> assemble(std::string_view source, int node,
-                            std::size_t T21_size) {
+                            std::size_t T21_size, bool permissive) {
 	auto lines = kblib::split_dsv(source, '\n');
-	if (lines.size() > T21_size) {
-		throw std::invalid_argument{concat("too many lines of asm for node ",
-		                                   node, "; ", lines.size(),
-		                                   " exceeds limit ", T21_size)};
-	}
 	std::vector<instr> ret;
 	std::map<std::string, word_t, std::less<>> labels;
 
 	int l{};
+	int noncode_lines{};
 	for (auto& line : lines) {
-		// Apparently the game allows ! anywhere as long as there's only one
+		if (not permissive and line.length() > 18) {
+			throw std::invalid_argument{concat('@', node, ':', l, ": Line ",
+			                                   kblib::quoted(line), " too long (",
+			                                   line.length(), " chars)")};
+		}
+		// The game allows ! anywhere as long as there's only one per line
 		if (auto bang = line.find_first_of('!'); bang != std::string::npos) {
 			line[bang] = ' ';
 		}
@@ -142,8 +138,12 @@ std::vector<instr> assemble(std::string_view source, int node,
 		    = kblib::split_tokens(line.substr(0, line.find_first_of('#')),
 		                          [](char c) { return " \t,"sv.contains(c); });
 		// the game allows only a single label per line, but multiple labels can
-		// still be attached to the same instruction if put in different lines, we
-		// simply allow multiple labels per line
+		// still be attached to the same instruction if put in different lines.
+		// The --permissive flag allows multiple instructions on a single line.
+		if (tokens.empty()) {
+			++noncode_lines;
+		}
+		int label_count{};
 		for (const auto& tok : tokens) {
 			assert(not tok.empty());
 			std::string tmp;
@@ -160,6 +160,7 @@ std::vector<instr> assemble(std::string_view source, int node,
 					}
 					log_debug("L: ", tmp, " (", l, ")");
 					labels[std::exchange(tmp, "")] = to_word(l);
+					++label_count;
 				} else {
 					tmp.push_back(c);
 				}
@@ -169,8 +170,21 @@ std::vector<instr> assemble(std::string_view source, int node,
 				break;
 			}
 		}
+		if (not permissive and label_count > 1) {
+			throw std::invalid_argument{concat('@', node, ':', l, ": Line ",
+			                                   kblib::quoted(line),
+			                                   " has too many labels")};
+		}
 	}
 
+	// Blank lines and lines consisting only of comments don't count with
+	// --permissive
+	if ((permissive ? (lines.size() - noncode_lines) : lines.size())
+	    > T21_size) {
+		throw std::invalid_argument{concat("Too many lines of asm for node ",
+		                                   node, "; ", lines.size(),
+		                                   " exceeds limit ", T21_size)};
+	}
 	l = 0;
 	for (const auto& line : lines) {
 		bool seen_op{false};
@@ -225,7 +239,7 @@ std::vector<instr> assemble(std::string_view source, int node,
 				i.src = port::immediate;
 				i.val = to_word(immediate);
 			} else {
-				i.src = parse_port(token);
+				i.src = parse_port(token, not permissive);
 			}
 		};
 		if (not tokens.empty()) {
@@ -251,7 +265,7 @@ std::vector<instr> assemble(std::string_view source, int node,
 				i.op_ = mov;
 				assert_last_operand(2);
 				load_port_or_immediate(i, tokens[1]);
-				i.dst = parse_port(tokens[2]);
+				i.dst = parse_port(tokens[2], not permissive);
 			} else if (opcode == "ADD") {
 				i.op_ = add;
 				assert_last_operand(1);

--- a/parser.cpp
+++ b/parser.cpp
@@ -115,7 +115,7 @@ std::vector<instr> assemble(std::string_view source, int node,
 	int l{};
 	int noncode_lines{};
 	for (auto& line : lines) {
-		if (not permissive and line.length() > 18) {
+		if (not permissive and line.length() > max_line_length) {
 			throw std::invalid_argument{concat('@', node, ':', l, ": Line ",
 			                                   kblib::quoted(line), " too long (",
 			                                   line.length(), " chars)")};
@@ -137,12 +137,12 @@ std::vector<instr> assemble(std::string_view source, int node,
 		auto tokens
 		    = kblib::split_tokens(line.substr(0, line.find_first_of('#')),
 		                          [](char c) { return " \t,"sv.contains(c); });
-		// the game allows only a single label per line, but multiple labels can
-		// still be attached to the same instruction if put in different lines.
-		// The --permissive flag allows multiple instructions on a single line.
 		if (tokens.empty()) {
 			++noncode_lines;
 		}
+		// the game allows only a single label per line, but multiple labels can
+		// still be attached to the same instruction if put in different lines.
+		// The --permissive flag allows multiple labels on a single line.
 		int label_count{};
 		for (const auto& tok : tokens) {
 			assert(not tok.empty());
@@ -239,7 +239,7 @@ std::vector<instr> assemble(std::string_view source, int node,
 				i.src = port::immediate;
 				i.val = to_word(immediate);
 			} else {
-				i.src = parse_port(token, not permissive);
+				i.src = parse_port(token, permissive);
 			}
 		};
 		if (not tokens.empty()) {
@@ -265,7 +265,7 @@ std::vector<instr> assemble(std::string_view source, int node,
 				i.op_ = mov;
 				assert_last_operand(2);
 				load_port_or_immediate(i, tokens[1]);
-				i.dst = parse_port(tokens[2], not permissive);
+				i.dst = parse_port(tokens[2], permissive);
 			} else if (opcode == "ADD") {
 				i.op_ = add;
 				assert_last_operand(1);

--- a/parser.hpp
+++ b/parser.hpp
@@ -24,6 +24,6 @@
 
 /// Assemble a single node's code
 std::vector<instr> assemble(std::string_view source, int node,
-                            std::size_t T21_size);
+                            std::size_t T21_size, bool permissive);
 
 #endif // PARSER_HPP

--- a/sim.cpp
+++ b/sim.cpp
@@ -348,7 +348,7 @@ const score& tis_sim::simulate_code(std::string_view code) {
 		throw std::logic_error("No target level set");
 	}
 	field f = target_level->new_field(T30_size);
-	f.parse_code(code, T21_size);
+	f.parse_code(code, T21_size, permissive);
 	log_debug_r([&] { return "Layout:\n" + f.layout(); });
 
 	if (run_fixed) {

--- a/sim.hpp
+++ b/sim.hpp
@@ -62,6 +62,7 @@ class tis_sim {
 	uint T30_size = defaults::T30_size;
 	bool run_fixed = defaults::run_fixed;
 	bool compute_stats = false;
+	bool permissive = false;
 
  public:
 	// runtime
@@ -113,6 +114,7 @@ class tis_sim {
 	void set_T30_size(uint size_) { T30_size = size_; }
 	void set_run_fixed(bool v) { run_fixed = v; }
 	void set_compute_stats(bool v) { compute_stats = v; }
+	void set_permissive(bool v) { permissive = v; }
 
 	const score& simulate_code(std::string_view code);
 	const score& simulate_file(const std::string& solution);

--- a/tis100.cpp
+++ b/tis100.cpp
@@ -87,6 +87,10 @@ void tis_sim_set_compute_stats(tis_sim* sim, bool compute_stats) {
 	sim->set_compute_stats(compute_stats);
 }
 
+void tis_sim_set_permissive(tis_sim* sim, bool permissive) {
+	sim->set_permissive(permissive);
+}
+
 const struct score* tis_sim_simulate(tis_sim* sim, const char* code) {
 	try {
 		return &sim->simulate_code(std::string_view(code));

--- a/tis100.h
+++ b/tis100.h
@@ -75,6 +75,7 @@ void tis_sim_set_T21_size(struct tis_sim* sim, uint32_t T21_size);
 void tis_sim_set_T30_size(struct tis_sim* sim, uint32_t T30_size);
 void tis_sim_set_run_fixed(struct tis_sim* sim, bool run_fixed);
 void tis_sim_set_compute_stats(struct tis_sim* sim, bool compute_stats);
+void tis_sim_set_permissive(struct tis_sim* sim, bool permissive);
 
 // get simulation results
 const char* tis_sim_get_error_message(const struct tis_sim* sim);


### PR DESCRIPTION
Added: --permissive flag controls all lexer extensions. Namely: the present
line limit and port abbreviation changes, multiple labels on a line, and unlimited line length. Permissive mode is now off by default.

In short, only saves that the game could have saved are allowed (the numeric constant range limit is still enforced, making files the sim accepts without `--permissive` a strict subset of those the game accepts (theoretically)).

Added: Blank/comment lines no longer count towards the T21_size limit (when permissive). Labels without attached instructions still do.

Added: Port abbreviations can be arbitrary prefixes, "LEFT" and "ACC" have priority over "LAST" and "ANY". `parse_port` changed to search an array instead of use an if
ladder.